### PR TITLE
Use single quotes, makes cut&paste more practical

### DIFF
--- a/bin/smoke-test.sh
+++ b/bin/smoke-test.sh
@@ -702,7 +702,7 @@ for IP_ADDRESS in $ALL_IP_ADDRESSES; do
         TARGET_MACAROON="$THIS_ADDR_TARGET_MACAROON"
     fi
 
-    CURL_MACAROON="$CURL_BASE -H \"Authorization: Bearer $TARGET_MACAROON\"" # NB. StoRM requires "Bearer" not "bearer"
+    CURL_MACAROON="$CURL_BASE -H 'Authorization: Bearer $TARGET_MACAROON'" # NB. StoRM requires "Bearer" not "bearer"
 
     echo -n "Uploading to target with macaroon authz: "
     if [ $macaroonFailed -eq 0 ]; then


### PR DESCRIPTION
In case of errors having cut&paste working is practical