### PR TITLE
Add support for tokens requested via oidc-agent.

### DIFF
--- a/bin/smoke-em.sh
+++ b/bin/smoke-em.sh
@@ -30,7 +30,8 @@ ENDPOINTS=$BASE/etc/endpoints
 
 OUTPUT_DESCRIPTION="stdout"
 QUIET=0
-while getopts "h?e:s:m:xo:p:qS:" opt; do
+VO="dteam"
+while getopts "h?e:s:m:xo:p:qv:S:" opt; do
     case "$opt" in
         h|\?)
             echo "$0 -x [-s <addr> [-m <mailer>]] [-p <file>] [-S <file>] [-o <name>]"
@@ -41,6 +42,7 @@ while getopts "h?e:s:m:xo:p:qS:" opt; do
             echo "    -x           use extended tests, if supported"
             echo "    -p <file>    use <file> for persistent state"
             echo "    -q           limit output to errors and prompts"
+            echo "    -v <VO>      specify the VO to use for the tests"
             echo "    -S <file>    skip endpoints listed in <file>"
             echo "    -o <name>    use token auth from oidc-agent account <name>"
             exit 0
@@ -66,6 +68,9 @@ while getopts "h?e:s:m:xo:p:qS:" opt; do
             ;;
         q)
             QUIET=1
+            ;;
+        v)
+            VO="$OPTARG"
             ;;
         S)
             MANUAL_SKIP_FILE="$OPTARG"
@@ -171,6 +176,10 @@ runTests() {
 
         if [ ! -z "$OIDC_AGENT_ACCOUNT" ]; then
             options="$options -t wlcg -o $OIDC_AGENT_ACCOUNT"
+        fi
+
+        if [ ! -z "$VO" ]; then
+            options="$options -v $VO"
         fi
 
         if [[ "$workarounds" == *L* ]]; then
@@ -388,7 +397,7 @@ sendEmail() { # $1 - email address, $2 - subject
 
 voms-proxy-info -e >/dev/null 2>&1 || fatal "Need valid X.509 proxy"
 voms-proxy-info -e -hours 1 >/dev/null 2>&1 || fatal "X.509 proxy expires too soon"
-voms-proxy-info --acexists dteam 2>/dev/null || fatal "X.509 proxy does not assert dteam membership"
+voms-proxy-info --acexists $VO 2>/dev/null || fatal "X.509 proxy does not assert $VO membership"
 
 loadManualSkipped
 downloadGocDbDowntimeInfo

--- a/bin/smoke-test.sh
+++ b/bin/smoke-test.sh
@@ -58,7 +58,7 @@ extended=0
 tokenType=macaroon
 workarounds=""
 debugOutput=0
-vo=dteam
+vo=${SMOKE_TEST_VO:-dteam}
 
 withColour() {
     RESET="\x1B[0m"

--- a/etc/token-endpoints
+++ b/etc/token-endpoints
@@ -1,5 +1,4 @@
 NEBRASKA       xrootd-D/HDFS   -  https://red-gridftp1.unl.edu:1094/user/dteam
 CERN-EOSPPS    EOS             -  https://eospps.cern.ch:443/eos/opstest/tpc/https
 DESY-PROM-DCA  dCache          -  https://prometheus.desy.de:2443/VOs/dteam
-INFN-T1-STO    SToRM           -  https://xfer.cr.cnaf.infn.it:8443/dteam
 PRAGUELCG2-DPM DPM             -  https://golias100.farm.particle.cz:443/dpm/farm.particle.cz/home/dteam

--- a/etc/token-endpoints
+++ b/etc/token-endpoints
@@ -1,0 +1,5 @@
+NEBRASKA       xrootd-D/HDFS   -  https://red-gridftp1.unl.edu:1094/user/dteam
+CERN-EOSPPS    EOS             -  https://eospps.cern.ch:443/eos/opstest/tpc/https
+DESY-PROM-DCA  dCache          -  https://prometheus.desy.de:2443/VOs/dteam
+INFN-T1-STO    SToRM           -  https://xfer.cr.cnaf.infn.it:8443/dteam
+PRAGUELCG2-DPM DPM             -  https://golias100.farm.particle.cz:443/dpm/farm.particle.cz/home/dteam

--- a/etc/wlcg-token-endpoints
+++ b/etc/wlcg-token-endpoints
@@ -3,3 +3,4 @@ CERN-EOSPPS    EOS             -  https://eospps.cern.ch:443/eos/opstest/tpc/htt
 DESY-PROM-DCA  dCache          -  https://prometheus.desy.de:2443/VOs/wlcg
 INFN-T1-STO    SToRM           -  https://xfer.cr.cnaf.infn.it:8443/wlcg
 PRAGUELCG2-DPM DPM             -  https://golias100.farm.particle.cz:443/dpm/farm.particle.cz/home/wlcg
+MANCHESTER     DPM             -  https://vm33.in.tier2.hep.manchester.ac.uk/dpm/tier2.hep.manchester.ac.uk/home/wlcg

--- a/etc/wlcg-token-endpoints
+++ b/etc/wlcg-token-endpoints
@@ -1,0 +1,5 @@
+NEBRASKA       xrootd-D/HDFS   -  https://red-gridftp1.unl.edu:1094/user/dteam
+CERN-EOSPPS    EOS             -  https://eospps.cern.ch:443/eos/opstest/tpc/https
+DESY-PROM-DCA  dCache          -  https://prometheus.desy.de:2443/VOs/wlcg
+INFN-T1-STO    SToRM           -  https://xfer.cr.cnaf.infn.it:8443/wlcg
+PRAGUELCG2-DPM DPM             -  https://golias100.farm.particle.cz:443/dpm/farm.particle.cz/home/wlcg


### PR DESCRIPTION
Example invocation:

```
./bin/smoke-test.sh -o WLCG-XFER -t wlcg https://red-gridftp1.unl.edu:1094/user/dteam
```

(assuming that you have already run `oidc-add WLCG-XFER`)